### PR TITLE
[FEATURE] Automatically fetch scope domain

### DIFF
--- a/Classes/Api/OracleApi.php
+++ b/Classes/Api/OracleApi.php
@@ -20,17 +20,12 @@ class OracleApi
     /**
      * @var string
      */
-    protected $url;
+    protected $oceDomain;
 
     /**
      * @var string
      */
-    protected $tokenUrl;
-
-    /**
-     * @var string
-     */
-    protected $scope;
+    protected $tokenDomain;
 
     /**
      * @var string
@@ -53,17 +48,15 @@ class OracleApi
     protected $cachePolicy;
 
     /**
-     * @param string $url
-     * @param string $tokenUrl
-     * @param string $scope
+     * @param string $oceDomain
+     * @param string $tokenDomain
      * @param string $clientId
      * @param string $clientSecret
      */
-    public function __construct(string $url, string $tokenUrl, string $scope, string $clientId, string $clientSecret)
+    public function __construct(string $oceDomain, string $tokenDomain, string $clientId, string $clientSecret)
     {
-        $this->url = $url;
-        $this->tokenUrl = $tokenUrl;
-        $this->scope = $scope;
+        $this->oceDomain = $oceDomain;
+        $this->tokenDomain = $tokenDomain;
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
     }
@@ -77,13 +70,13 @@ class OracleApi
     {
         if (!($this->client instanceof Client)) {
             $authorizationClient  = new Client([
-                'base_uri' => $this->tokenUrl . '/oauth2/v1/token',
+                'base_uri' => 'https://' . $this->tokenDomain . '/oauth2/v1/token'
             ]);
 
             $authorizationConfiguration = [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
-                'scope' => $this->scope,
+                'scope' => 'https://' . $this->oceDomain . ':443/urn:opc:cec:all',
             ];
 
             $grantType = new ClientCredentials($authorizationClient, $authorizationConfiguration);
@@ -95,7 +88,7 @@ class OracleApi
             $stack->push($oauth);
 
             $this->client = new Client([
-                'base_uri' => $this->url,
+                'base_uri' => 'https://' . $this->oceDomain,
                 'handler' => $stack,
                 'auth' => 'oauth',
             ]);

--- a/Classes/Api/OracleApi.php
+++ b/Classes/Api/OracleApi.php
@@ -95,7 +95,7 @@ class OracleApi
     {
         if (!($this->client instanceof Client)) {
             $authorizationClient  = new Client([
-                'base_uri' => 'https://' . $this->tokenDomain . '/oauth2/v1/token'
+                'base_uri' => 'https://' . $this->tokenDomain . '/oauth2/v1/token',
             ]);
 
             $authorizationConfiguration = [

--- a/Classes/Configuration/ExtensionConfigurationManager.php
+++ b/Classes/Configuration/ExtensionConfigurationManager.php
@@ -47,7 +47,7 @@ class ExtensionConfigurationManager implements SingletonInterface
     protected $clientSecret;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $scope;
 
@@ -97,6 +97,11 @@ class ExtensionConfigurationManager implements SingletonInterface
             'APP_ORACLE_DAM_TOKEN_DOMAIN',
             'tokenDomain'
         );
+
+        $this->scope = $this->getFromEnvironmentOrExtensionConfiguration(
+            'APP_ORACLE_DAM_SCOPE',
+            'scopeDomain'
+        ) ?: null;
     }
 
     /**
@@ -165,7 +170,6 @@ class ExtensionConfigurationManager implements SingletonInterface
             && !empty($this->clientId)
             && !empty($this->clientSecret)
             && !empty($this->javaScriptUiUrl)
-            && !empty($this->scope)
             && !empty($this->tokenDomain);
     }
 
@@ -183,6 +187,14 @@ class ExtensionConfigurationManager implements SingletonInterface
     public function getClientSecret(): string
     {
         return $this->clientSecret;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScopeDomain(): ?string
+    {
+        return $this->scope;
     }
 
     /**

--- a/Classes/Configuration/ExtensionConfigurationManager.php
+++ b/Classes/Configuration/ExtensionConfigurationManager.php
@@ -93,11 +93,6 @@ class ExtensionConfigurationManager implements SingletonInterface
             'clientSecret'
         );
 
-        $this->scope = $this->getFromEnvironmentOrExtensionConfiguration(
-            'APP_ORACLE_DAM_SCOPE',
-            'scope'
-        );
-
         $this->tokenDomain = $this->getFromEnvironmentOrExtensionConfiguration(
             'APP_ORACLE_DAM_TOKEN_DOMAIN',
             'tokenDomain'
@@ -188,14 +183,6 @@ class ExtensionConfigurationManager implements SingletonInterface
     public function getClientSecret(): string
     {
         return $this->clientSecret;
-    }
-
-    /**
-     * @return string
-     */
-    public function getScope(): string
-    {
-        return $this->scope;
     }
 
     /**

--- a/Classes/Domain/Repository/AbstractOracleDamRepository.php
+++ b/Classes/Domain/Repository/AbstractOracleDamRepository.php
@@ -30,9 +30,8 @@ abstract class AbstractOracleDamRepository implements SingletonInterface
     protected function getOracleApi(ExtensionConfigurationManager $configuration): OracleApi
     {
         return new OracleApi(
-            'https://' . $configuration->getOceDomain(),
-            'https://' . $configuration->getTokenDomain(),
-            $configuration->getScope(),
+            $configuration->getOceDomain(),
+            $configuration->getTokenDomain(),
             $configuration->getClientId(),
             $configuration->getClientSecret()
         );

--- a/Classes/Domain/Repository/AbstractOracleDamRepository.php
+++ b/Classes/Domain/Repository/AbstractOracleDamRepository.php
@@ -33,7 +33,8 @@ abstract class AbstractOracleDamRepository implements SingletonInterface
             $configuration->getOceDomain(),
             $configuration->getTokenDomain(),
             $configuration->getClientId(),
-            $configuration->getClientSecret()
+            $configuration->getClientSecret(),
+            $configuration->getScopeDomain()
         );
     }
 }

--- a/Documentation/Configuration.rst
+++ b/Documentation/Configuration.rst
@@ -72,16 +72,6 @@ Basic
    The client secret for the OCM OAuth client application. Used for server-side interaction with the DAM. More info in
    the `OCM documentation <https://docs.oracle.com/en/cloud/paas/content-cloud/solutions/integrate-oracle-content-management-using-oauth.html#GUID-AC061A7E-6488-4BCB-AAB6-C9928AF23EE0>`__
 
-.. confval:: scope
-
-   :Required: true
-   :type: string
-   :Environment variable: APP_ORACLE_DAM_SCOPE
-   :Example: 012345678-9abc-def0-1234-56789abcdef
-
-   Authentication scope for the OCM OAuth client application. A complete URL ending in "urn:opc:cec:all". A full Used for server-side interaction with the DAM. More info in
-   the `OCM documentation <https://docs.oracle.com/en/cloud/paas/content-cloud/solutions/integrate-oracle-content-management-using-oauth.html#GUID-AC061A7E-6488-4BCB-AAB6-C9928AF23EE0>`__
-
 .. confval:: tokenDomain
 
    :Required: true

--- a/Documentation/Configuration.rst
+++ b/Documentation/Configuration.rst
@@ -95,3 +95,15 @@ Advanced
    :Default: https://static.ocecdn.oraclecloud.com/cdn/cec/api/oracle-ce-ui-2.11.js
 
    The URL to the JavaScript file for the image selector UI.
+
+.. confval:: scopeDomain
+
+   :Required: false
+   :type: string
+   :Environment variable: APP_ORACLE_DAM_SCOPE
+   :Example: 0123456789abcdef0123456789abcdef.cec.ocp.oraclecloud.com
+
+   Usually resolved automatically, as it is the hostname that the
+   :ref:`oceDomain` CNAME record is pointing to. This property is used for
+   server-side OAuth authentication when interacting with the DAM. More info in
+   the `OCM documentation <https://docs.oracle.com/en/cloud/paas/content-cloud/solutions/integrate-oracle-content-management-using-oauth.html#GUID-AC061A7E-6488-4BCB-AAB6-C9928AF23EE0>`__

--- a/Tests/Unit/Api/OracleApiTest.php
+++ b/Tests/Unit/Api/OracleApiTest.php
@@ -16,7 +16,7 @@ class OracleApiTest extends UnitTestCase
     {
         parent::setUp();
 
-        $this->subject = new OracleApi('url', 'tokenUrl', 'scope', 'clientId', 'clientSecret');
+        $this->subject = new OracleApi('url', 'tokenUrl', 'scope', 'clientId', null, 'clientSecret');
     }
 
     /**

--- a/Tests/Unit/Api/OracleApiTest.php
+++ b/Tests/Unit/Api/OracleApiTest.php
@@ -16,7 +16,7 @@ class OracleApiTest extends UnitTestCase
     {
         parent::setUp();
 
-        $this->subject = new OracleApi('url', 'tokenUrl', 'scope', 'clientId', null, 'clientSecret');
+        $this->subject = new OracleApi('url', 'tokenUrl', 'clientId', 'clientSecret', 'scope');
     }
 
     /**

--- a/Tests/Unit/Configuration/ExtensionConfigurationManagerTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationManagerTest.php
@@ -173,7 +173,6 @@ class ExtensionConfigurationManagerTest extends UnitTestCase
             'APP_ORACLE_DAM_JS_URL' => 'theJsUrlFromEnvironment',
             'APP_ORACLE_DAM_CLIENT' => 'theClientFromEnvironment',
             'APP_ORACLE_DAM_SECRET' => 'theSecretFromEnvironment',
-            'APP_ORACLE_DAM_SCOPE' => 'theScopeFromEnvironment',
             'APP_ORACLE_DAM_TOKEN_DOMAIN' => 'theTokenDomainFromEnvironment',
         ];
 

--- a/Tests/Unit/Configuration/ExtensionConfigurationManagerTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationManagerTest.php
@@ -73,8 +73,8 @@ class ExtensionConfigurationManagerTest extends UnitTestCase
 
         self::assertEquals(
             $values['APP_ORACLE_DAM_SCOPE'],
-            $subject->getScope(),
-            'getScope() returns value of environment variable APP_ORACLE_DAM_SCOPE'
+            $subject->getScopeDomain(),
+            'getScopeDomain() returns value of environment variable APP_ORACLE_DAM_SCOPE'
         );
 
         self::assertEquals(
@@ -100,7 +100,7 @@ class ExtensionConfigurationManagerTest extends UnitTestCase
             'jsUiUrl' => 'theJsUrlFromExtensionConfig',
             'clientId' => 'theClientFromExtensionConfig',
             'clientSecret' => 'theSecretFromExtensionConfig',
-            'scope' => 'theScopeFromExtensionConfig',
+            'scopeDomain' => 'theScopeFromExtensionConfig',
             'tokenDomain' => 'theTokenDomainFromExtensionConfig',
         ];
 
@@ -149,9 +149,9 @@ class ExtensionConfigurationManagerTest extends UnitTestCase
         );
 
         self::assertEquals(
-            $values['scope'],
-            $subject->getScope(),
-            'getScope() returns value of extension configuration property scope'
+            $values['scopeDomain'],
+            $subject->getScopeDomain(),
+            'getScopeDomain() returns value of extension configuration property scopeDomain'
         );
 
         self::assertEquals(

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,11 +13,11 @@ clientId =
 # cat=basic/configure/5; type=string; label=OAuth Client Secret: From the OCM client application.
 clientSecret =
 
-# cat=basic/configure/6; type=string; label=OAuth Authentication Scope: Ending in "urn:opc:cec:all". From the OCM client application.
-scope =
-
 # cat=basic/configure/6; type=string; label=Token Endpoint Domain: A domain ending in "identity.oraclecloud.com" for use when authenticating.
 tokenDomain =
 
-# cat=advanced/configure/3; type=string; label=JavaScript URL: Override the default URL of the selector UI JavaScript.
+# cat=advanced/configure/1; type=string; label=JavaScript URL: Override the default URL of the selector UI JavaScript.
 jsUiUrl =
+
+# cat=advanced/configure/2; type=string; label=OAuth Authentication Scope Domain: Usually resolved automatically as it is the hostname that the OCE domain's CNAME record is pointing to.
+scopeDomain =


### PR DESCRIPTION
The scope domain is where the CNAME record of the oceDomain points. If no CNAME record exists, the oceDomain is used, as it logically follows that a domain without CNAME record cannot be resolved further and thus must be the scope domain. 

This means the scope string doesn't have to be specified by the integrator when configuring the extension. 

The scope domain can still be preconfigured (forcibly overridden) in configuration.